### PR TITLE
Add Blobset Docs and Python Logging

### DIFF
--- a/clientlib/python/src/udmi/core/logging/mqtt_handler.py
+++ b/clientlib/python/src/udmi/core/logging/mqtt_handler.py
@@ -59,10 +59,13 @@ class UDMIMqttLogHandler(logging.Handler):
             timestamp = datetime.fromtimestamp(record.created,
                                                tz=timezone.utc).isoformat()
 
+            category = getattr(record, "category", None)
+
             log_entry = Entry(
                 message=msg,
                 level=udmi_level,
-                timestamp=timestamp
+                timestamp=timestamp,
+                category=category
             )
 
             system_event = SystemEvents(

--- a/clientlib/python/src/udmi/core/managers/system_manager.py
+++ b/clientlib/python/src/udmi/core/managers/system_manager.py
@@ -363,6 +363,8 @@ class SystemManager(BaseManager):
 
             LOGGER.info("New generation detected for blob '%s': %s",
                         key, blob_config.generation)
+            LOGGER.info("Received blob update config for %s", key,
+                        extra={"category": "blobset.blob.receive"})
             self._apply_blob(key, blob_config)
 
     def _apply_blob(self, key: str, config: BlobBlobsetConfig) -> None:
@@ -394,6 +396,8 @@ class SystemManager(BaseManager):
         os.close(tmp_fd)
 
         try:
+            LOGGER.info("Extract blob data for %s", key,
+                        extra={"category": "blobset.blob.extract"})
             LOGGER.info("Streaming blob '%s' to %s...", key, tmp_path)
             get_verified_blob_file(config, tmp_path)
 
@@ -406,10 +410,12 @@ class SystemManager(BaseManager):
                 with open(tmp_path, 'rb') as f:
                     payload = f.read()
 
+            LOGGER.info("Staging blob update...",
+                        extra={"category": "blobset.blob.apply"})
             LOGGER.info("Invoking handler for blob '%s'...", key)
             process_output = handler.process(key, payload)
 
-            LOGGER.info("Blob '%s' applied successfully.", key)
+            LOGGER.info("Blob '%s' successfully staged, publishing final state", key)
             self._applied_blob_generations[key] = config.generation
             self._update_blob_state(key, Phase.final, config.generation)
             self.trigger_state_update(immediate=True)
@@ -419,10 +425,13 @@ class SystemManager(BaseManager):
                                              self._applied_blob_generations)
 
             if handler.post_process:
+                LOGGER.info("Activating blob update...",
+                            extra={"category": "blobset.blob.apply"})
                 handler.post_process(key, process_output)
 
         except Exception as e:  # pylint:disable=broad-exception-caught
-            LOGGER.error("Failed to apply blob '%s': %s", key, e)
+            LOGGER.error("Failed to apply blob '%s': %s", key, e,
+                         extra={"category": "blobset.blob.apply.failure"})
             self._update_blob_state(key, Phase.final, config.generation, str(e))
             self.trigger_state_update()
 
@@ -440,7 +449,8 @@ class SystemManager(BaseManager):
             status_entry = Entry(
                 message=error_message,
                 level=500,
-                timestamp=datetime.now(timezone.utc).isoformat()
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                category="blobset.blob.apply"
             )
 
         self._blob_states[key] = BlobBlobsetState(

--- a/docs/specs/sequences/blobset.md
+++ b/docs/specs/sequences/blobset.md
@@ -1,0 +1,39 @@
+[**UDMI**](../../../) / [**Docs**](../../) / [**Specs**](../) / [**Sequences**](./) / [Blobset](#)
+
+# Blobset Updates
+
+The blobset feature allows for the delivery of binary large objects (blobs) or configuration data to a device via UDMI configuration messages. It orchestrates a strict two-phase deployment process to ensure device state remains synchronized with the cloud before disruptive actions (like a restart) occur.
+
+## Two-Phase Deployment Pipeline
+
+1. **Stage (Phase 1):** The payload is safely downloaded and verified without triggering disruptive actions.
+2. **Activate (Phase 2):** The staged blob is activated (which may involve disruptive actions like a restart), but only after the device has successfully published its `FINAL` state to the cloud.
+
+This ordering guarantees the cloud is aware of the successful update before the device potentially drops its connection during activation.
+
+## Flow
+
+1. **Receive Config:** The device receives a configuration update containing a blob in the `blobset.blobs` map with a specific generation and a phase of `final`.
+2. **Apply Phase:** The device evaluates the blob against its current state. If the device's applied generation does not match the config generation, it transitions its state phase to `apply`.
+3. **Fetch and Verify:** The device securely fetches the binary payload using the provided `url` and cryptographically verifies its integrity against the provided `sha256` hash.
+4. **Stage:** The device performs Phase 1 (staging) by parsing, validating, or saving the data without disrupting core operations.
+5. **Final State:** The device transitions the state phase to `final` and clears any previous error statuses. This state is immediately published to the cloud.
+6. **Persist:** The newly applied generation string is persisted locally so it survives restarts.
+7. **Activate:** The device performs Phase 2 (activation). This may include a process restart, service reload, or applying new firmware.
+
+## Example Configuration
+
+```json
+{
+  "blobset": {
+    "blobs": {
+      "firmware": {
+        "phase": "final",
+        "url": "https://example.com/firmware.bin",
+        "sha256": "9c8423ac2e707a40c239fce4ce52b8c05ae8c32b163927b9350c97d0f64a8cf7",
+        "generation": "2023-01-01T12:00:00Z"
+      }
+    }
+  }
+}
+```

--- a/docs/specs/sequences/readme.md
+++ b/docs/specs/sequences/readme.md
@@ -13,5 +13,6 @@ More explanatory detail for some of the key functional specifications:
 
 - [Config and State](config.md): Basic handling of _config_ and _state_ messages.
 - [Discovery](discovery.md): Flow for on-prem network and point discovery.
+- [Blobset](blobset.md): Delivery of binary data and two-phase deployment pipeline.
 - [Endpoint Reconfiguration](endpoint_reconfiguration.md): Ability to reconfigure endpoint (e.g. MQTT) from the cloud
 - [Writeback](writeback.md): Ability to control on-prem resources from the cloud.


### PR DESCRIPTION
This change documents the blob updates sequence based on the pubber Java library implementation, and brings the Python client library to parity with the Java pubber library for standard blobset logging.

---
*PR created automatically by Jules for task [8087768644619514735](https://jules.google.com/task/8087768644619514735) started by @khyatimahendru*